### PR TITLE
Fixed potential cause of build failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ project/_site/
 .Rhistory
 *.DS_Store*
 /_site
+
+/.quarto/

--- a/project/_quarto.yml
+++ b/project/_quarto.yml
@@ -216,25 +216,25 @@ website:
           - text: Instrumental Variables II
             file: docs/4_Advanced/advanced_instrumental_variables/advanced_instrumental_variables2.qmd
           - text: Large Language Model APIs (Python)
-            file: docs\4_Advanced\advanced_llm_apis2\advanced_llm_apis2.qmd
+            file: docs/4_Advanced/advanced_llm_apis2/advanced_llm_apis2.qmd
           - text: Linear Differencing
             file: docs/4_Advanced/advanced_linear_differencing/advanced_linear_differencing.qmd
           - text: Training LLMS
-            file: docs\4_Advanced\advanced_ollama_llm\fine_tuning_llm.qmd
+            file: docs/4_Advanced/advanced_ollama_llm/fine_tuning_llm.qmd
           - text: Sentiment Analysis Using LLMs (Python)
-            file: docs\4_Advanced\advanced_sentiment_analysis\sentiment_analysis.qmd
+            file: docs/4_Advanced/advanced_sentiment_analysis/sentiment_analysis.qmd
           - text: Transcription (Python)
             file: docs/4_Advanced/advanced_transcription/advanced_transcription_whisper.qmd
           - text: Vocalization (Python)
             file: docs/4_Advanced/advanced_vocalization/advanced_vocalization_draft.qmd
           - text: Word Embeddings (Python)
-            file: docs\4_Advanced\advanced_word_embeddings\advanced_word_embeddings_python_version.qmd
+            file: docs/4_Advanced/advanced_word_embeddings/advanced_word_embeddings_python_version.qmd
           - text: Word Embeddings (R)
-            file: docs\4_Advanced\advanced_word_embeddings\advanced_word_embeddings_r_version.qmd
+            file: docs/4_Advanced/advanced_word_embeddings/advanced_word_embeddings_r_version.qmd
           - text: Panel Data
-            file: docs\4_Advanced\advanced_panel_data\advanced_panel_data.qmd
+            file: docs/4_Advanced/advanced_panel_data/advanced_panel_data.qmd
           - text: Synthetic Controls
-            file: docs\4_Advanced\advanced_synthetic_control\advanced_synthetic_control.qmd
+            file: docs/4_Advanced/advanced_synthetic_control/advanced_synthetic_control.qmd
 
 
     - title: "Learn by Class"

--- a/project/docs/4_Advanced/advanced_network_analysis/network_analysis_notebook_II.qmd
+++ b/project/docs/4_Advanced/advanced_network_analysis/network_analysis_notebook_II.qmd
@@ -544,7 +544,7 @@ print(f"Number of edges in subgraph: {len(G_sub.edges())}")
 
 This demonstration is not perfect, when the code is ran locally it works much better with the edges rendering. Below is a screenshot from my own machine showing how it would would look locally. 
 
-![Locally rendered Map of our dataset](media\example_map.png){width=80% fig-alt="Network"}
+![Locally rendered Map of our dataset](media/example_map.png){width=80% fig-alt="Network"}
 
 On this map you can pan, zoom, hover over nodes, and use the box and lasso select tools. 
 


### PR DESCRIPTION
The following issues were mainly fixed:
Incorrect use of `\` instead of `/` in qmd file and `_quarto.yml` prevented directory from being located correctly in ubuntu.

In addition to this, testing locally with `act` and docker containers did not fully simulate due to a missing GitHub environment variable for `ACTIONS_RUNTIME_TOKEN`, but the rendering session was completed correctly.

After that I tried to build directly from branch but encountered `Error: ENOENT: no such file or directory, realpath '/home/runner/work/comet-open/comet-open/artifacts/var/log/ nginx/access.log'` error, suspected to be related to not building from main.

The exact completion is shown in the screenshot.

![image](https://github.com/user-attachments/assets/d50bc5bd-3e72-4e73-95cd-7fc2f34d56c6)
